### PR TITLE
Improve ref management to avoid some errors with string refs.

### DIFF
--- a/src/with-dimension.js
+++ b/src/with-dimension.js
@@ -82,7 +82,7 @@ const withDimension = ({
   }
 
   updateDimensions = () => {
-    const elem = this.refs.withDimensionContainer
+    const elem = this.withDimensionContainer
 
     if (!this.canUpdate) { return }
     if (this.state.containerWidth === getWidth(elem)
@@ -96,10 +96,14 @@ const withDimension = ({
     }
   }
 
+  updateWithDimensionContainerRef = (node) => {
+    this.withDimensionContainer = node
+  }
+
   render() {
     return (
       <div
-        ref={'withDimensionContainer'}
+        ref={this.updateWithDimensionContainerRef}
         style={containerStyle}
       >
         <BaseComponent


### PR DESCRIPTION
This change does not cause any break, it only changes the refs management way...

```js
// this throws error
ReactDOM.render(<App ref='xxxx' />, document.getElementById('app'))

// works fine
let xxx
ReactDOM.render(<App ref={(node) => xxx = node} />, document.getElementById('app'))
```